### PR TITLE
Update BYOC Module for Current Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,21 @@ This module allows you to provision the infrastructure needed for an Earthly BYO
 
 ### Module Inputs
 
-| Name           | Description                                                                                                                                              |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| cloud_name     | The name to use to identify the cloud installation. Used by Earthly during automatic installation, and to mark related resources in AWS.                 |
-| subnet         | The subnet Earthly will deploy satellites into.                                                                                                          |
-| ssh_public_key | (Optional) The SSH key to include in provisioned satellites. If left unspecified, a new key is generated, and the private key is available as an output. |
+| Name             | Description                                                                                                                                              |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| cloud_name       | The name to use to identify the cloud installation. Used by Earthly during automatic installation, and to mark related resources in AWS.                 |
+| subnet           | The subnet Earthly will deploy satellites into.                                                                                                          |
+| ssh_public_key   | (Optional) The SSH key to include in provisioned satellites. If left unspecified, a new key is generated, and the private key is available as an output. |
+| sg_cidr_override | (Optional) An override for the instance security group CIDR. If left unspecified, the rules will be generated with the CIDR of the configured subnet.    |
 
 
 ### Module Outputs
 
-| Name                 | Description                                                                                                                              |
-|----------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| installation_name    | The name to use to identify the cloud installation. Used by Earthly during automatic installation, and to mark related resources in AWS. |
-| security_group_id    | The ID of the security group for new satellites.                                                                                         |
-| ssh_key_name         | The name of the SSH key in AWS that is included in new satellites.                                                                       |
-| ssh_private_key      | (Sensitive) The private key, if `ssh_public_key` is unspecified.                                                                         |
-| instance_profile_arn | The ARN of the instance profile satellite instances will use for logging.                                                                |
-| compute_role_arn     | The ARN of the role Earthly will assume to orchestrate satellites on your behalf.                                                        |
+| Name                  | Description                                                                                                                              |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| installation_name     | The name to use to identify the cloud installation. Used by Earthly during automatic installation, and to mark related resources in AWS. |
+| security_group_id     | The ID of the security group for new satellites.                                                                                         |
+| ssh_key_name          | The name of the SSH key in AWS that is included in new satellites.                                                                       |
+| ssh_private_key       | (Sensitive) The private key, if `ssh_public_key` is unspecified.                                                                         |
+| instance_profile_name | The name of the instance profile satellite instances will use for logging.                                                               |
+| compute_role_arn      | The ARN of the role Earthly will assume to orchestrate satellites on your behalf.                                                        |

--- a/main.tf
+++ b/main.tf
@@ -60,9 +60,13 @@ resource "aws_vpc_security_group_egress_rule" "open_outbound" {
 
 resource "aws_vpc_security_group_ingress_rule" "satellite_ssh" {
   security_group_id = aws_security_group.satellite_security_group.id
+  cidr_ipv4 = (
+    var.sg_cidr_override == ""
+    ? data.aws_subnet.current.cidr_block
+    : var.sg_cidr_override
+  )
 
   description = "Allow SSH access from within the satellite's subnet"
-  cidr_ipv4   = data.aws_subnet.current.cidr_block
   ip_protocol = "tcp"
   from_port   = 22
   to_port     = 22
@@ -70,9 +74,13 @@ resource "aws_vpc_security_group_ingress_rule" "satellite_ssh" {
 
 resource "aws_vpc_security_group_ingress_rule" "satellite_buildkit" {
   security_group_id = aws_security_group.satellite_security_group.id
+  cidr_ipv4 = (
+    var.sg_cidr_override == ""
+    ? data.aws_subnet.current.cidr_block
+    : var.sg_cidr_override
+  )
 
   description = "Allow BuildKit access from within the satellite's subnet"
-  cidr_ipv4   = data.aws_subnet.current.cidr_block
   ip_protocol = "tcp"
   from_port   = 8372
   to_port     = 8372
@@ -80,9 +88,13 @@ resource "aws_vpc_security_group_ingress_rule" "satellite_buildkit" {
 
 resource "aws_vpc_security_group_ingress_rule" "satellite_prometheus" {
   security_group_id = aws_security_group.satellite_security_group.id
+  cidr_ipv4 = (
+    var.sg_cidr_override == ""
+    ? data.aws_subnet.current.cidr_block
+    : var.sg_cidr_override
+  )
 
   description = "Allow Prometheus access from within the satellite's subnet"
-  cidr_ipv4   = data.aws_subnet.current.cidr_block
   ip_protocol = "tcp"
   from_port   = 9000
   to_port     = 9000

--- a/main.tf
+++ b/main.tf
@@ -109,13 +109,15 @@ resource "aws_vpc_security_group_ingress_rule" "satellite_prometheus" {
 resource "aws_iam_role" satellite_instance_role {
   description = "The instance role for Satellites"
   path = "/earthly/satellites/${var.cloud_name}/"
-  managed_policy_arns = [
-    aws_iam_policy.satellite_instance_policy.arn
-  ]
   max_session_duration = 3600
   name = "${var.cloud_name}-satellite-instance"
   assume_role_policy = data.aws_iam_policy_document.satellite_instance_assume_role_policy_document.json
   tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "satellite_instance_policy_attachment" {
+  role       = aws_iam_role.satellite_instance_role.name
+  policy_arn = aws_iam_policy.satellite_instance_policy.arn
 }
 
 data aws_iam_policy_document satellite_instance_assume_role_policy_document {

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_vpc_security_group_ingress_rule" "satellite_ssh" {
     : var.sg_cidr_override
   )
 
-  description = "Allow SSH access from within the satellite's subnet"
+  description = "Allow SSH access from the satellites subnet"
   ip_protocol = "tcp"
   from_port   = 22
   to_port     = 22
@@ -80,7 +80,7 @@ resource "aws_vpc_security_group_ingress_rule" "satellite_buildkit" {
     : var.sg_cidr_override
   )
 
-  description = "Allow BuildKit access from within the satellite's subnet"
+  description = "Allow BuildKit access from the satellites subnet"
   ip_protocol = "tcp"
   from_port   = 8372
   to_port     = 8372
@@ -94,7 +94,7 @@ resource "aws_vpc_security_group_ingress_rule" "satellite_prometheus" {
     : var.sg_cidr_override
   )
 
-  description = "Allow Prometheus access from within the satellite's subnet"
+  description = "Allow Prometheus access from the satellites subnet"
   ip_protocol = "tcp"
   from_port   = 9000
   to_port     = 9000

--- a/main.tf
+++ b/main.tf
@@ -47,41 +47,47 @@ resource "aws_security_group" satellite_security_group {
   name = "${var.cloud_name}-satellites-access"
   description = "Minimal required rules for satellites."
   vpc_id = data.aws_subnet.current.vpc_id
-
-  ingress {
-      cidr_blocks = [data.aws_subnet.current.cidr_block]
-      protocol = "tcp"
-      description = "Allow SSH access from within the ingress subnet"
-      from_port = 22
-      to_port = 22
-  }
-
-  ingress {
-      cidr_blocks = [data.aws_subnet.current.cidr_block]
-      protocol = "tcp"
-      description = "Allow Buildkit access from within the ingress subnet"
-      from_port = 8372
-      to_port = 8372
-  }
-
-  ingress {
-      cidr_blocks = [data.aws_subnet.current.cidr_block]
-      protocol = "tcp"
-      description = "Allow Prometheus access from within the ingress subnet"
-      from_port = 9000
-      to_port = 9000
-  }
-
-  egress {
-      cidr_blocks = ["0.0.0.0/0"]
-      protocol = -1
-      description = "Satellites have general outbound access to whatever they need"
-      from_port = 0
-      to_port = 0
-    }
-
   tags = local.tags
 }
+
+resource "aws_vpc_security_group_egress_rule" "open_outbound" {
+  security_group_id = aws_security_group.satellite_security_group.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+  description = "Satellites have general outbound access to whatever they need"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "satellite_ssh" {
+  security_group_id = aws_security_group.satellite_security_group.id
+
+  description = "Allow SSH access from within the satellite's subnet"
+  cidr_ipv4   = data.aws_subnet.current.cidr_block
+  ip_protocol = "tcp"
+  from_port   = 22
+  to_port     = 22
+}
+
+resource "aws_vpc_security_group_ingress_rule" "satellite_buildkit" {
+  security_group_id = aws_security_group.satellite_security_group.id
+
+  description = "Allow BuildKit access from within the satellite's subnet"
+  cidr_ipv4   = data.aws_subnet.current.cidr_block
+  ip_protocol = "tcp"
+  from_port   = 8372
+  to_port     = 8372
+}
+
+resource "aws_vpc_security_group_ingress_rule" "satellite_prometheus" {
+  security_group_id = aws_security_group.satellite_security_group.id
+
+  description = "Allow Prometheus access from within the satellite's subnet"
+  cidr_ipv4   = data.aws_subnet.current.cidr_block
+  ip_protocol = "tcp"
+  from_port   = 9000
+  to_port     = 9000
+}
+
 
 ## ---------------------------------------------------------------------------------------------------------------------
 ## SATELLITE INSTANCE ROLE

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,9 +37,9 @@ output "ssh_private_key" {
   )
 }
 
-output "instance_profile_arn" {
-  description = "The ARN of the instance profile satellites use for logging in a given cloud installation."
-  value       = aws_iam_instance_profile.satellite_instance_profile.arn
+output "instance_profile_name" {
+  description = "The name of the instance profile satellites use for logging in a given cloud installation."
+  value       = aws_iam_instance_profile.satellite_instance_profile.name
 }
 
 output "compute_role_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable subnet {
   type = string
 }
 
+variable sg_cidr_override {
+  description = "Overrides the CIDR used in security group rules for the satellites"
+  type        = string
+  default     = ""
+}
+
 variable ssh_public_key {
   description = "The public key to use when provisioning your satellites. No value generates a key for you and stores the private key in your outputs."
   type = string


### PR DESCRIPTION
This PR contains a few changes to add flexibility in managing the Security Group and Instance Role attached to the satellite instances.

**Changes**

* **Move Ingress/Egress fields in SG definition to explicit resources**
AWS deprecated the use of the `ingress` and `egress` fields in the `aws_security_group` resource. [On the reference page](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) there are both a Warning and Note discussing how the resource configured to use these fields may have issues managing multiple CIDRs and explicitly warns not to use these fields with specific Ingress/Egress rules. Since we want to be able to attach additional rules I've moved the existing rules into specific resources.

* **Added an override variable for SG rule CIDRs**
By default the ingress rules use the subnet's CIDR. In our use case this was too restrictive so I've added a new variable, `sg_cidr_override` that if specified will be used as the rule's CIDR instead of the subnet's CIDR

* **Changed the `instance_profile` output to the name instead of ARN**
In order to read an `instance_profile` as data you need to specify the name of it instead of its ARN. [See the data reference page](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile)

* **Changed the policy attachment method to an explicit attachment resource**
AWS notes in [the aws_iam_role reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) that `managed_policy_arns` is not compatible with `aws_iam_role_policy_attachment`s. Since we're adding additional policies, the module can't use `managed_policy_arns`
